### PR TITLE
Python3 pickle error with bytes

### DIFF
--- a/scripts/create-combined-class1-dataset.py
+++ b/scripts/create-combined-class1-dataset.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print("Reading %s..." % args.iedb_pickle_path)
-    with open(args.iedb_pickle_path, "r") as f:
+    with open(args.iedb_pickle_path, "rb") as f:
         iedb_datasets = pickle.load(f)
 
     print("Reading %s..." % args.netmhcpan_csv_path)

--- a/scripts/create-iedb-class1-dataset.py
+++ b/scripts/create-iedb-class1-dataset.py
@@ -84,5 +84,5 @@ if __name__ == "__main__":
                 "percent_positive",
                 "count"])
         print("# distinct pMHC entries: %d" % len(columns["mhc"]))
-    with open(OUTPUT_PATH, "w") as f:
+    with open(OUTPUT_PATH, "wb") as f:
         pickle.dump(assay_dataframes, f, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
When running `scripts/create-iedb-class1-dataset.py`, it gives the following error on py3:

```
Traceback (most recent call last):
  File "scripts/create-iedb-class1-dataset.py", line 88, in <module>
    pickle.dump(assay_dataframes, f, pickle.HIGHEST_PROTOCOL)
TypeError: must be str, not bytes
```