### PR TITLE
added batch normalization between layers, changed default weight initialization

### DIFF
--- a/mhcflurry/class1_binding_predictor.py
+++ b/mhcflurry/class1_binding_predictor.py
@@ -37,7 +37,15 @@ from .serialization_helpers import (
     save_keras_model_to_disk
 )
 from .peptide_encoding import check_valid_index_encoding_array
-from .feedforward_hyperparameters import LOSS, OPTIMIZER
+from .feedforward_hyperparameters import (
+    LOSS,
+    OPTIMIZER,
+    ACTIVATION,
+    BATCH_NORMALIZATION,
+    INITIALIZATION_METHOD,
+    DROPOUT_PROBABILITY,
+    HIDDEN_LAYER_SIZE
+)
 from .regression_target import MAX_IC50, ic50_to_regression_target
 from .training_helpers import (
     combine_training_arrays,
@@ -121,13 +129,14 @@ class Class1BindingPredictor(Class1AlleleSpecificKmerIC50PredictorBase):
             n_amino_acids=20,
             allow_unknown_amino_acids=True,
             embedding_output_dim=20,
-            layer_sizes=[50],
-            activation="tanh",
-            init="lecun_uniform",
+            layer_sizes=[HIDDEN_LAYER_SIZE],
+            activation=ACTIVATION,
+            init=INITIALIZATION_METHOD,
             output_activation="sigmoid",
-            dropout_probability=0,
+            dropout_probability=DROPOUT_PROBABILITY,
             loss=LOSS,
             optimizer=OPTIMIZER,
+            batch_normalization=BATCH_NORMALIZATION,
             **kwargs):
         """
         Create untrained predictor with the given hyperparameters.

--- a/mhcflurry/feedforward_hyperparameters.py
+++ b/mhcflurry/feedforward_hyperparameters.py
@@ -21,7 +21,7 @@ from .common import all_combinations
 # keeping these for compatibility with old code
 N_EPOCHS = 250
 ACTIVATION = "tanh"
-INITIALIZATION_METHOD = "lecun_uniform"
+INITIALIZATION_METHOD = "glorot_uniform"
 EMBEDDING_DIM = 32
 HIDDEN_LAYER_SIZE = 100
 DROPOUT_PROBABILITY = 0.1
@@ -29,6 +29,7 @@ LEARNING_RATE = 0.001
 OPTIMIZER = "rmsprop"
 LOSS = "mse"
 BATCH_SIZE = 32
+BATCH_NORMALIZATION = True
 
 Params = namedtuple("Params", [
     "activation",
@@ -41,6 +42,7 @@ Params = namedtuple("Params", [
     "optimizer",
     "n_training_epochs",
     "batch_size",
+    "batch_normalization",
 ])
 
 default_hyperparameters = Params(
@@ -53,7 +55,8 @@ default_hyperparameters = Params(
     loss=LOSS,
     optimizer=OPTIMIZER,
     n_training_epochs=N_EPOCHS,
-    batch_size=BATCH_SIZE)
+    batch_size=BATCH_SIZE,
+    batch_normalization=BATCH_NORMALIZATION)
 
 def all_combinations_of_hyperparameters(**kwargs):
     # enusre that all parameters are members of the Params object

--- a/script/mhcflurry-dataset-size-sensitivity.py
+++ b/script/mhcflurry-dataset-size-sensitivity.py
@@ -94,8 +94,9 @@ parser.add_argument(
 parser.add_argument(
     "--pretraining-weight-decay",
     choices=("exponential", "quadratic", "linear"),
-    default="quadratic",
+    default="exponential",
     help="Rate at which weight of imputed samples decays")
+
 """
 parser.add_argument(
     "--remove-similar-peptides-from-test-data",

--- a/test/test_neural_nets.py
+++ b/test/test_neural_nets.py
@@ -14,7 +14,8 @@ def test_make_embedding_network_properties():
         n_amino_acids=3,
         layer_sizes=layer_sizes,
         loss=mse,
-        optimizer=RMSprop(lr=0.7, rho=0.9, epsilon=1e-6))
+        optimizer=RMSprop(lr=0.7, rho=0.9, epsilon=1e-6),
+        batch_normalization=False,)
     eq_(nn.layers[0].input_dim, 3)
     eq_(nn.loss, mse)
     assert np.allclose(nn.optimizer.lr.eval(), 0.7)
@@ -31,6 +32,7 @@ def test_make_hotshot_network_properties():
         init="lecun_uniform",
         loss=mse,
         layer_sizes=layer_sizes,
+        batch_normalization=False,
         optimizer=RMSprop(lr=0.7, rho=0.9, epsilon=1e-6))
     eq_(nn.layers[0].input_dim, 6)
     eq_(nn.loss, mse)


### PR DESCRIPTION
Difference between initialization algorithms:
- "lecun_uniform" : divides weights by fan_in of layer 
- "glorot_uniform" divides by fan_in + fan_out

Another "small" change that could have significant impact on trained models: switched the decay rate of weights on imputed data back to "exponential" from "quadratic" (imputed data gets ignored after fewer epochs, models train faster). 