### PR TITLE
dockerize take 2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+LICENSE
+*.txt
+*.csv
+*.zip
+*.swp
+!requirements.txt
+experiments

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM nvidia/cuda:cudnn-runtime
+
+MAINTAINER Tim O'Donnell <timodonnell@gmail.com>
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    apt-get update && \
+    apt-get install --yes \
+        python3-dev python-dev \
+        python-virtualenv \
+        libblas-dev \
+        liblapack-dev \
+        gfortran \
+        libhdf5-serial-dev \
+        libyaml-dev \
+        libzmq3-dev \
+        libfreetype6-dev \
+        libpng12-dev \
+        pkg-config && \
+    apt-get clean && \
+    useradd --create-home --home-dir /home/user --shell /bin/bash user
+
+# Set the locale (otherwise dask-distributed complains).
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8 
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+USER user
+ENV HOME=/home/user
+ENV SHELL=/bin/bash
+ENV USER=user
+WORKDIR /home/user
+
+# Setup virtual envs and install convenience packages.
+RUN virtualenv venv-py3 --python=python3 && \
+    venv-py3/bin/pip install distributed jupyter seaborn && \
+    virtualenv venv-py2 --python=python && \
+    venv-py2/bin/pip install distributed jupyter seaborn
+
+# Install mhcflurry.
+COPY . ./mhcflurry
+RUN venv-py3/bin/pip install ./mhcflurry && venv-py2/bin/pip install ./mhcflurry
+ 
+EXPOSE 8888
+CMD venv-py3/bin/jupyter notebook --no-browser

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,23 +5,27 @@ MAINTAINER Tim O'Donnell <timodonnell@gmail.com>
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
     apt-get update && \
     apt-get install --yes \
-        python3-dev python-dev \
-        python-virtualenv \
-        libblas-dev \
-        liblapack-dev \
         gfortran \
+        libatlas-base-dev \
+        libatlas3gf-base \
+        libblas-dev \
+        libfreetype6-dev \
         libhdf5-serial-dev \
+        liblapack-dev \
+        libpng12-dev \
         libyaml-dev \
         libzmq3-dev \
-        libfreetype6-dev \
-        libpng12-dev \
-        pkg-config && \
+        pkg-config \
+        python-virtualenv \
+        python3-dev \
+        python-dev && \
     apt-get clean && \
-    useradd --create-home --home-dir /home/user --shell /bin/bash user
-
+    useradd --create-home --home-dir /home/user --shell /bin/bash -G sudo user && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+        
 # Set the locale (otherwise dask-distributed complains).
 RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8 
+ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
@@ -31,11 +35,14 @@ ENV SHELL=/bin/bash
 ENV USER=user
 WORKDIR /home/user
 
-# Setup virtual envs and install convenience packages.
+# Setup virtual envs and install convenience packages.  Note: installing
+# cherrypy as part of the mhcflurry installation weirdly fails on a unicode
+# issue in python2, but installing it separately seems to work. We also install
+# bokeh so that dask distributed will have an admin web interface.
 RUN virtualenv venv-py3 --python=python3 && \
-    venv-py3/bin/pip install distributed jupyter seaborn && \
+    venv-py3/bin/pip install cherrypy bokeh distributed jupyter seaborn && \
     virtualenv venv-py2 --python=python && \
-    venv-py2/bin/pip install distributed jupyter seaborn
+    venv-py2/bin/pip install cherrypy bokeh distributed jupyter seaborn
 
 # Install mhcflurry.
 COPY . ./mhcflurry

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>= 1.11
 pandas>=0.13.1
 appdirs
 theano>=0.8.2
-keras<1.0
+keras
 h5py
 cherrypy
 bottle


### PR DESCRIPTION
This is an attempt to have a single docker image that can be used as a base for cloud runs (with mhcflurry-cloud) and also eventually as a way for users to experiment with mhcflurry. Plan is to have this built automatically at https://hub.docker.com/r/hammerlab/mhcflurry/

 * supports cpu and theoretically gpu (not tested though)
 * supports python 2 and 3
 * putting Dockerfile in the root of our repo lets us just copy the current checkout of the mhcflurry repo into the image instead of pulling it from github, so it works with branches and non-released versions
 * by default this runs a python 3 jupyter notebook on port 8888 with mhcflurry and some convenience packages installed
 * does not try to train any models or run tests. Models will eventually be downloaded from google cloud storage once we have that working
 * it’s pretty hefty unfortunately, around 2 gig

Also: removed the pin on keras<1.0 in requirements.txt