### PR TITLE
Bump travis python 3 version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false  # Use container-based infrastructure
 language: python
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the


### PR DESCRIPTION
Trying to hunt down why mhcflurry is failing to install due to an exception raised in keras on py 3.6 here (cc @rohanpai ): https://gist.github.com/rohanpai/9603a92c155d7e3ea795c71f0b0a27e0