### PR TITLE
Reuse Keras models optimization

### DIFF
--- a/mhcflurry/__init__.py
+++ b/mhcflurry/__init__.py
@@ -17,7 +17,7 @@ from .class1_affinity_prediction.class1_neural_network import (
 from .class1_affinity_prediction.class1_affinity_predictor import (
     Class1AffinityPredictor)
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 __all__ = [
     "Class1NeuralNetwork",

--- a/mhcflurry/downloads.yml
+++ b/mhcflurry/downloads.yml
@@ -8,7 +8,7 @@
 # by name, the downloads with "default=true" are downloaded.
 
 # This should usually be the latest release.
-current-release: 0.9.1
+current-release: 0.9.2
 
 # An integer indicating what models the current MHCflurry code base is compatible
 # with. Increment this integer when changes are made to MHCflurry that would break
@@ -17,6 +17,30 @@ current-compatibility-version: 2
 
 # Add new releases here as they are made.
 releases:
+    0.9.2:
+        compatibility-version: 2
+        downloads:
+            - name: models_class1
+              url: http://github.com/hammerlab/mhcflurry/releases/download/0.9.2/models_class1.tar.bz2
+              default: true
+
+            - name: data_curated
+              url: https://github.com/hammerlab/mhcflurry/releases/download/0.9.1/data_curated.tar.bz2
+              default: true
+
+            - name: data_kim2014
+              url: http://github.com/hammerlab/mhcflurry/releases/download/0.9.1/data_kim2014.tar.bz2
+              default: false
+
+            - name: data_iedb
+              url: https://github.com/hammerlab/mhcflurry/releases/download/0.9.1/data_iedb.tar.bz2
+              default: false
+
+            - name: models_class1_experiments1
+              url: http://github.com/hammerlab/mhcflurry/releases/download/0.9.2/models_class1_experiments1.tar.bz2
+              default: false
+
+
     0.9.1:
         compatibility-version: 2
         downloads:

--- a/test/test_class1_neural_network.py
+++ b/test/test_class1_neural_network.py
@@ -18,7 +18,13 @@ def test_class1_affinity_predictor_a0205_training_accuracy():
         max_epochs=500,
         early_stopping=False,
         validation_split=0.0,
-        locally_connected_layers=[],
+        locally_connected_layers=[
+            {
+                "filters": 8,
+                "activation": "tanh",
+                "kernel_size": 3
+            }
+        ],
         dense_layer_l1_regularization=0.0,
         dropout_probability=0.0)
 
@@ -51,3 +57,26 @@ def test_class1_affinity_predictor_a0205_training_accuracy():
         numpy.log(ic50_true),
         rtol=0.2,
         atol=0.2)
+
+    # Test that a second predictor has the same architecture json.
+    # This is important for an optimization we use to re-use predictors of the
+    # same architecture at prediction time.
+    hyperparameters2 = dict(
+        activation="tanh",
+        layer_sizes=[16],
+        max_epochs=1,
+        early_stopping=False,
+        validation_split=0.0,
+        locally_connected_layers=[
+            {
+                "filters": 8,
+                "activation": "tanh",
+                "kernel_size": 3
+            }
+        ],
+        dense_layer_l1_regularization=0.0,
+        dropout_probability=0.0)
+    predictor2 = Class1NeuralNetwork(**hyperparameters2)
+    predictor2.fit(df.peptide.values, df.measurement_value.values)
+    eq_(predictor.network().to_json(), predictor2.network().to_json())
+


### PR DESCRIPTION
This should give a substantial prediction speed improvement as identified by @rohanpai

* Add borrow_cached_network() method to Class1NeuralNetwork
* Use cached models at in Class1NeuralNetwork.predict
* Set names for all neural network layers so the model JSON is identical for identical architectures